### PR TITLE
Fix gsub config.active_job.queue_adapter in install_generator.rb

### DIFF
--- a/lib/generators/litestack/install/install_generator.rb
+++ b/lib/generators/litestack/install/install_generator.rb
@@ -20,7 +20,7 @@ class Litestack::InstallGenerator < Rails::Generators::Base
 
   def modify_active_job_adapter
     gsub_file "config/environments/production.rb",
-      "# config.active_job.queue_adapter     = :resque",
+      "# config.active_job.queue_adapter = :resque",
       "config.active_job.queue_adapter = :litejob"
   end
 


### PR DESCRIPTION
Fixing space issue in install generator so that it sets `active_job.queue_adapter` to `:litejob` in production